### PR TITLE
Add `autoPinSelf` config to automatically pin when joining meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Example Url with parameters: http://localhost:3000?token=replaceWithYourMeetingT
 | sideStackSize                   | -             | -                                                                                           |
 | reduceEdgeSpacing               | false         | -                                                                                           |
 | isRecorder                      | false         | -                                                                                           |
+| autoPinSelf                     | false         | Automatically pin local participant                                                         |
 
 ---
 

--- a/src/App.js
+++ b/src/App.js
@@ -78,6 +78,7 @@ const App = () => {
       isRecorder: "isRecorder",
       leftScreenRejoinButtonEnabled: "leftScreenRejoinButtonEnabled",
       joinWithoutUserInteraction: "joinWithoutUserInteraction",
+      autoPinSelf: "autoPinSelf",
       rawUserAgent: "rawUserAgent",
     };
 
@@ -471,6 +472,7 @@ const App = () => {
             sideStackSize: paramKeys.sideStackSize,
             reduceEdgeSpacing: paramKeys.reduceEdgeSpacing === "true",
             isRecorder: paramKeys.isRecorder === "true",
+            autoPinSelf: paramKeys.autoPinSelf === "true",
           }}
         >
           <MeetingProvider

--- a/src/MeetingAppContextDef.js
+++ b/src/MeetingAppContextDef.js
@@ -92,6 +92,7 @@ export const MeetingAppProvider = ({
   sideStackSize,
   reduceEdgeSpacing,
   isRecorder,
+  autoPinSelf,
 }) => {
   const containerRef = useRef();
   const endCallContainerRef = useRef();
@@ -181,6 +182,7 @@ export const MeetingAppProvider = ({
         sideStackSize,
         reduceEdgeSpacing,
         isRecorder,
+        autoPinSelf,
 
         // states
         sideBarMode,

--- a/src/meetingContainer/MeetingContainer.js
+++ b/src/meetingContainer/MeetingContainer.js
@@ -125,6 +125,7 @@ const MeetingContainer = () => {
     topbarEnabled,
     notificationAlertsEnabled,
     debug,
+    autoPinSelf,
   } = useMeetingAppContext();
 
   const topBarHeight = topbarEnabled ? 60 : 0;
@@ -166,6 +167,10 @@ const MeetingContainer = () => {
           resolve();
         }, 500);
       });
+    }
+
+    if (autoPinSelf) {
+      mMeetingRef.current.localParticipant.pin();
     }
   };
 


### PR DESCRIPTION
**Story**

As a presenter,
I want to be pinned automatically when joining a meeting
So I don't have to re-pin myself everytime I join a meeting where I am already identified as a presenter.

**Use case**

We have multiple "rooms" with "presenters" and "viewers". 

Both presenters and viewers will move from one room to another frequently. 

Viewers should never be "visible", while presenters should always be.

The most SOLID way of implementing this I found was re-using the "pin" function.

**Testing**

Use the following configs:

```
layout=SPOTLIGHT
autoPinSelf=true | false
```

One browser with `autoPinSelf` as `true`, the other as `false`. 

The user with `autoPinSelf=true` should be visible, while the other will be automatically hidden.

URL ex:

```
http://localhost:3000/?meetingId={{ your meeting id }}&webcamEnabled=false&micEnabled=false&name={{ your name }}&joinScreenEnabled=false&joinWithoutUserInteraction=true&canPin=true&layout=SPOTLIGHT&autoPinSelf=true&token={{ your token }}
```